### PR TITLE
bugfix： 修复方法调用链路重复的问题

### DIFF
--- a/GCDFetchFeed/GCDFetchFeed.xcodeproj/project.pbxproj
+++ b/GCDFetchFeed/GCDFetchFeed.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		3EE311701C4E212700103FA3 /* SMRootViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EE3116F1C4E212700103FA3 /* SMRootViewController.m */; };
 		3EE311751C4E303600103FA3 /* SMFeedModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EE311741C4E303600103FA3 /* SMFeedModel.m */; };
 		8F3DCFAC671E00110311BDBE /* Pods_GCDFetchFeed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3796ACD85E2DA28F1711CF41 /* Pods_GCDFetchFeed.framework */; };
+		D9DCCA782B329A1D00465F0F /* SMCallTraceDemo.m in Sources */ = {isa = PBXBuildFile; fileRef = D9DCCA772B329A1D00465F0F /* SMCallTraceDemo.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -86,7 +87,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		055B62180119DC2D35BCADD9 /* Pods-GCDFetchFeed.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GCDFetchFeed.debug.xcconfig"; path = "Pods/Target Support Files/Pods-GCDFetchFeed/Pods-GCDFetchFeed.debug.xcconfig"; sourceTree = "<group>"; };
 		0866301727293784009D4501 /* fishhook.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = fishhook.c; sourceTree = "<group>"; };
 		0866301827293784009D4501 /* fishhook.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fishhook.h; sourceTree = "<group>"; };
 		0A12F2661DE96864002ED910 /* STMURLCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STMURLCache.h; sourceTree = "<group>"; };
@@ -147,6 +147,7 @@
 		0AEE64951D881563009E21C7 /* SMMapViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SMMapViewController.m; sourceTree = "<group>"; };
 		0AEE64981D883058009E21C7 /* ArtWork.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ArtWork.h; sourceTree = "<group>"; };
 		0AEE64991D883058009E21C7 /* ArtWork.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ArtWork.m; sourceTree = "<group>"; };
+		0E1C8B15B6322EA774EE06D2 /* Pods-GCDFetchFeed.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GCDFetchFeed.release.xcconfig"; path = "Pods/Target Support Files/Pods-GCDFetchFeed/Pods-GCDFetchFeed.release.xcconfig"; sourceTree = "<group>"; };
 		3796ACD85E2DA28F1711CF41 /* Pods_GCDFetchFeed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GCDFetchFeed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3E58A8511C507BFD0026A610 /* SMRootCellViewModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SMRootCellViewModel.h; sourceTree = "<group>"; };
 		3E58A8521C507BFD0026A610 /* SMRootCellViewModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SMRootCellViewModel.m; sourceTree = "<group>"; };
@@ -210,7 +211,9 @@
 		3EE3116F1C4E212700103FA3 /* SMRootViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SMRootViewController.m; sourceTree = "<group>"; };
 		3EE311731C4E303600103FA3 /* SMFeedModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SMFeedModel.h; sourceTree = "<group>"; };
 		3EE311741C4E303600103FA3 /* SMFeedModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SMFeedModel.m; sourceTree = "<group>"; };
-		BB29081F4A19D8EFBD4887AF /* Pods-GCDFetchFeed.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GCDFetchFeed.release.xcconfig"; path = "Pods/Target Support Files/Pods-GCDFetchFeed/Pods-GCDFetchFeed.release.xcconfig"; sourceTree = "<group>"; };
+		8123E856919C2C01C5BED146 /* Pods-GCDFetchFeed.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GCDFetchFeed.debug.xcconfig"; path = "Pods/Target Support Files/Pods-GCDFetchFeed/Pods-GCDFetchFeed.debug.xcconfig"; sourceTree = "<group>"; };
+		D9DCCA762B329A1D00465F0F /* SMCallTraceDemo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SMCallTraceDemo.h; sourceTree = "<group>"; };
+		D9DCCA772B329A1D00465F0F /* SMCallTraceDemo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SMCallTraceDemo.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -266,6 +269,8 @@
 			isa = PBXGroup;
 			children = (
 				0A35AD421F45B2D000780172 /* SMLagMonitor */,
+				D9DCCA762B329A1D00465F0F /* SMCallTraceDemo.h */,
+				D9DCCA772B329A1D00465F0F /* SMCallTraceDemo.m */,
 			);
 			path = Lib;
 			sourceTree = "<group>";
@@ -604,8 +609,8 @@
 		A386EE4060ADD261E13CC63F /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				055B62180119DC2D35BCADD9 /* Pods-GCDFetchFeed.debug.xcconfig */,
-				BB29081F4A19D8EFBD4887AF /* Pods-GCDFetchFeed.release.xcconfig */,
+				8123E856919C2C01C5BED146 /* Pods-GCDFetchFeed.debug.xcconfig */,
+				0E1C8B15B6322EA774EE06D2 /* Pods-GCDFetchFeed.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -687,7 +692,8 @@
 				TargetAttributes = {
 					3EE311371C4E1F0800103FA3 = {
 						CreatedOnToolsVersion = 7.2;
-						DevelopmentTeam = 962Z8PV35L;
+						DevelopmentTeam = TKRM4J3XJV;
+						ProvisioningStyle = Manual;
 					};
 					3EE311501C4E1F0800103FA3 = {
 						CreatedOnToolsVersion = 7.2;
@@ -863,6 +869,7 @@
 				3E8341EF1C5257F4002C3EAA /* SMFeedListViewController.m in Sources */,
 				0AEE649A1D883058009E21C7 /* ArtWork.m in Sources */,
 				0A35AD4B1F45B32600780172 /* SMStackCell.m in Sources */,
+				D9DCCA782B329A1D00465F0F /* SMCallTraceDemo.m in Sources */,
 				3E58A8601C50B7270026A610 /* SMTitleLabel.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -992,23 +999,27 @@
 		};
 		3EE311661C4E1F0800103FA3 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 055B62180119DC2D35BCADD9 /* Pods-GCDFetchFeed.debug.xcconfig */;
+			baseConfigurationReference = 8123E856919C2C01C5BED146 /* Pods-GCDFetchFeed.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = 962Z8PV35L;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = TKRM4J3XJV;
 				INFOPLIST_FILE = GCDFetchFeed/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_CFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.starming.GCDFetchFeed;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = JingxiDev_18;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
 		3EE311671C4E1F0800103FA3 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BB29081F4A19D8EFBD4887AF /* Pods-GCDFetchFeed.release.xcconfig */;
+			baseConfigurationReference = 0E1C8B15B6322EA774EE06D2 /* Pods-GCDFetchFeed.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";

--- a/GCDFetchFeed/GCDFetchFeed.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/GCDFetchFeed/GCDFetchFeed.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/GCDFetchFeed/GCDFetchFeed/AppDelegate.m
+++ b/GCDFetchFeed/GCDFetchFeed/AppDelegate.m
@@ -14,6 +14,7 @@
 #import "SMStyle.h"
 #import "SMFeedModel.h"
 #import "SMLagMonitor.h"
+#import "SMCallTraceDemo.h"
 
 #import <dlfcn.h>
 
@@ -25,6 +26,9 @@
 
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    
+    [SMCallTraceDemo test];
+    
     //这里是做卡顿监测
 //    [[SMLagMonitor shareInstance] beginMonitor];
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];

--- a/GCDFetchFeed/GCDFetchFeed/Lib/SMCallTraceDemo.h
+++ b/GCDFetchFeed/GCDFetchFeed/Lib/SMCallTraceDemo.h
@@ -1,0 +1,19 @@
+//
+//  SMCallTraceDemo.h
+//  GCDFetchFeed
+//
+//  Created by denglibing on 2023/12/20.
+//  Copyright © 2023 Starming. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SMCallTraceDemo : NSObject
+
++ (void)test;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/GCDFetchFeed/GCDFetchFeed/Lib/SMCallTraceDemo.m
+++ b/GCDFetchFeed/GCDFetchFeed/Lib/SMCallTraceDemo.m
@@ -1,0 +1,100 @@
+//
+//  SMCallTraceDemo.m
+//  GCDFetchFeed
+//
+//  Created by denglibing on 2023/12/20.
+//  Copyright © 2023 Starming. All rights reserved.
+//
+
+#import "SMCallTraceDemo.h"
+
+#import "SMCallTrace.h"
+
+@implementation SMCallTraceDemo
+
++ (void)test {
+    [SMCallTrace start];
+    
+    [self test1_1];
+    [self test2_1];
+    [self test3_1];
+    
+    [self test1_1];
+    [self test2_1];
+    [self test3_1];
+    
+    [SMCallTrace stop];
+    [SMCallTrace save];
+    
+    // 打印的日志如下：
+    /*
+     0|  39.11|+[SMCallTraceDemo test1_1]
+     1|  13.03|  +[SMCallTraceDemo test1_2]
+     1|  14.02|  +[SMCallTraceDemo test1_3]
+
+     0|  69.08|+[SMCallTraceDemo test2_1]
+     1|  23.02|  +[SMCallTraceDemo test2_2]
+     1|  24.03|  +[SMCallTraceDemo test2_3]
+
+     0|  99.32|+[SMCallTraceDemo test3_1]
+     1|  33.13|  +[SMCallTraceDemo test3_2]
+     1|  34.14|  +[SMCallTraceDemo test3_3]
+
+     0|  39.29|+[SMCallTraceDemo test1_1]
+     1|  13.09|  +[SMCallTraceDemo test1_2]
+     1|  14.06|  +[SMCallTraceDemo test1_3]
+
+     0|  68.76|+[SMCallTraceDemo test2_1]
+     1|  23.06|  +[SMCallTraceDemo test2_2]
+     1|  24.13|  +[SMCallTraceDemo test2_3]
+
+     0|  99.24|+[SMCallTraceDemo test3_1]
+     1|  33.09|  +[SMCallTraceDemo test3_2]
+     1|  34.07|  +[SMCallTraceDemo test3_3]
+     */
+}
+
++ (void)test1_1 {
+    usleep(11 * 1000);
+    [self test1_2];
+    [self test1_3];
+}
+
++ (void)test1_2 {
+    usleep(12 * 1000);
+}
+
++ (void)test1_3 {
+    usleep(13 * 1000);
+}
+
++ (void)test2_1 {
+    usleep(21 * 1000);
+    [self test2_2];
+    [self test2_3];
+}
+
++ (void)test2_2 {
+    usleep(22 * 1000);
+}
+
++ (void)test2_3 {
+    usleep(23 * 1000);
+}
+
+
++ (void)test3_1 {
+    usleep(31 * 1000);
+    [self test3_2];
+    [self test3_3];
+}
+
++ (void)test3_2 {
+    usleep(32 * 1000);
+}
+
++ (void)test3_3 {
+    usleep(33 * 1000);
+}
+
+@end

--- a/GCDFetchFeed/GCDFetchFeed/Lib/SMLagMonitor/SMCallTraceCore.h
+++ b/GCDFetchFeed/GCDFetchFeed/Lib/SMLagMonitor/SMCallTraceCore.h
@@ -12,11 +12,13 @@
 #include <stdio.h>
 #include <objc/objc.h>
 
-typedef struct {
+typedef struct smCallRecord {
     __unsafe_unretained Class cls;
     SEL sel;
     uint64_t time; // us (1/1000 ms)
     int depth;
+    uintptr_t lr; // link register
+    struct smCallRecord *caller_record;
 } smCallRecord;
 
 extern void smCallTraceStart();

--- a/GCDFetchFeed/GCDFetchFeed/Lib/SMLagMonitor/SMCallTraceTimeCostModel.h
+++ b/GCDFetchFeed/GCDFetchFeed/Lib/SMLagMonitor/SMCallTraceTimeCostModel.h
@@ -20,6 +20,9 @@
 @property (nonatomic, assign) NSUInteger frequency;      //访问频次
 @property (nonatomic, strong) NSArray <SMCallTraceTimeCostModel *> *subCosts;
 
+@property (nonatomic, assign) uintptr_t lr;              // 自身的 Link Register
+@property (nonatomic, assign) uintptr_t callerLr;        // 调用者的 Link Register
+
 - (NSString *)des;
 
 @end


### PR DESCRIPTION
**问题描述：** 方法的调用链不能根据 callDepth 来判断，不然所有层级相等的深度，都在一个调用链路中了。 
**解决方案：** 通过 lr 作为方法调用的标识，作为方法调用链更加合理。
**测试验证：** 新增 `+[SMCallTraceDemo test]` 测试代码来验证 lr 的合理性。测试数据如下：

```
     0|  39.11|+[SMCallTraceDemo test1_1]
     1|  13.03|  +[SMCallTraceDemo test1_2]
     1|  14.02|  +[SMCallTraceDemo test1_3]

     0|  69.08|+[SMCallTraceDemo test2_1]
     1|  23.02|  +[SMCallTraceDemo test2_2]
     1|  24.03|  +[SMCallTraceDemo test2_3]

     0|  99.32|+[SMCallTraceDemo test3_1]
     1|  33.13|  +[SMCallTraceDemo test3_2]
     1|  34.14|  +[SMCallTraceDemo test3_3]

     0|  39.29|+[SMCallTraceDemo test1_1]
     1|  13.09|  +[SMCallTraceDemo test1_2]
     1|  14.06|  +[SMCallTraceDemo test1_3]

     0|  68.76|+[SMCallTraceDemo test2_1]
     1|  23.06|  +[SMCallTraceDemo test2_2]
     1|  24.13|  +[SMCallTraceDemo test2_3]

     0|  99.24|+[SMCallTraceDemo test3_1]
     1|  33.09|  +[SMCallTraceDemo test3_2]
     1|  34.07|  +[SMCallTraceDemo test3_3]
```